### PR TITLE
[stable/datadog] add dnsConfig and dnsPolicy parameters

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.38.7
+version: 1.38.8
 appVersion: 6.14.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -292,6 +292,8 @@ helm install --name <RELEASE_NAME> \
 | `daemonset.nodeSelector`                 | Node selectors                                                                            | `nil`                                       |
 | `daemonset.affinity`                     | Node affinities                                                                           | `nil`                                       |
 | `daemonset.useHostNetwork`               | If true, use the host's network                                                           | `nil`                                       |
+| `daemonset.dnsPolicy`                    | Set DNS policy                                                                            | `nil`                                       |
+| `daemonset.dnsConfig`                    | Set DNS Config settings                                                                   | `nil`                                       |
 | `daemonset.useHostPID`.                  | If true, use the host's PID namespace                                                     | `nil`                                       |
 | `daemonset.useHostPort`                  | If true, use the same ports for both host and container                                   | `nil`                                       |
 | `daemonset.useDedicatedContainers`       | If true, each Datadog agent will run in a separate container                              | `nil`                                       |

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -58,8 +58,9 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       {{- else }}
-      hostNetwork: false
-      dnsPolicy: {{ if .Values.daemonset.dnsPolicy }}{{ .Values.daemonset.dnsPolicy }}{{ else }}ClusterFirst{{ end }}
+      {{- if .Values.daemonset.dnsPolicy }}
+      dnsPolicy: {{ .Values.daemonset.dnsPolicy }}
+      {{- end }}
       {{- end }}
       {{- if .Values.daemonset.dnsConfig }}
       dnsConfig:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
 {{ toYaml .Values.datadog.securityContext | indent 8 }}
       {{- end }}
       {{- if .Values.daemonset.useHostNetwork }}
-      hostNetwork: true
+      hostNetwork: {{ .Values.daemonset.useHostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet
       {{- else }}
       {{- if .Values.daemonset.dnsPolicy }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -55,8 +55,18 @@ spec:
 {{ toYaml .Values.datadog.securityContext | indent 8 }}
       {{- end }}
       {{- if .Values.daemonset.useHostNetwork }}
-      hostNetwork: {{ .Values.daemonset.useHostNetwork }}
+      hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      {{- else }}
+      hostNetwork: false
+      dnsPolicy: {{ if .Values.daemonset.dnsPolicy }}{{ .Values.daemonset.dnsPolicy }}{{ else }}ClusterFirst{{ end }}
+      {{- end }}
+      {{- if .Values.daemonset.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.daemonset.dnsConfig | indent 8 }}
+      {{- end }}
+      {{- if .Values.daemonset.useHostPort }}
+      hostPort: {{ .Values.daemonset.useHostPort }}
       {{- end }}
       {{- if .Values.daemonset.useHostPID }}
       hostPID: {{ .Values.daemonset.useHostPID }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -619,6 +619,29 @@ daemonset:
   #
   # useHostNetwork: true
 
+  ## @param dnsPolicy - string - optional
+  ## Set pod-specific DNS policy. Accepted values are:
+  ## Default, ClusterFirst, ClusterFirstWithHostNet, None
+  ##
+  ## WARNING: This parameter will be ignored if useHostNetwork is true
+  #
+  # dnsPolicy: ClusterFirst
+
+  ## @param dnsConfig - string - optional (required if dnsPolicy is None)
+  ## Configure nameservers, searches and options. If dnsPolicy is None, at least
+  ## one nameserver is required. Otherwise all subparameters are optional.
+  #
+  # dnsConfig:
+  #   nameservers:
+  #     - 1.2.3.4
+  #   searches:
+  #     - ns1.svc.cluster-domain.example
+  #     - my.dns.search.suffix
+  #   options:
+  #     - name: ndots
+  #       value: "2"
+  #     - name: edns0
+
   ## @param useHostPort - boolean - optional
   ## Sets the hostPort to the same value of the container port. Needs to be used
   ## to receive traces in a standard APM set up. Can be used as for sending custom metrics.


### PR DESCRIPTION
This is a PR against a fork of helm/charts .


#### Is this a new chart
No

#### What this PR does / why we need it:
Makes DNS policy and DNS config configurable 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
